### PR TITLE
Windows paths with spaces fix

### DIFF
--- a/lib/git-log-utils.js
+++ b/lib/git-log-utils.js
@@ -52,7 +52,7 @@
         directory = Path.dirname(fileName);
       }
       fileName = Path.normalize(this._escapeForCli(fileName));
-      cmd = "git log" + flags + " " + fileName;
+      cmd = "git log" + flags + " \"" + fileName + "\"";
       if (process.env.DEBUG === '1') {
         console.log('$ ' + cmd);
       }
@@ -112,7 +112,7 @@
     GitLogUtils._escapeForCli = function(filePath) {
       var escapePrefix;
       escapePrefix = process.platform === 'win32' ? '^' : '\\';
-      return filePath.replace(/([\s\(\)])/g, escapePrefix + '$1');
+      return filePath.replace(/([\(\)])/g, escapePrefix + '$1');
     };
 
     return GitLogUtils;

--- a/src/git-log-utils.coffee
+++ b/src/git-log-utils.coffee
@@ -50,7 +50,7 @@ module.exports = class GitLogUtils
       
     fileName = Path.normalize(@_escapeForCli(fileName))
     
-    cmd = "git log#{flags} #{fileName}"
+    cmd = "git log#{flags} \"#{fileName}\""
     console.log '$ ' + cmd if process.env.DEBUG == '1'
     return ChildProcess.execSync(cmd,  {stdio: 'pipe', cwd: directory}).toString()
     
@@ -98,4 +98,4 @@ module.exports = class GitLogUtils
   ###
   @_escapeForCli: (filePath) ->
     escapePrefix = if process.platform == 'win32' then '^' else '\\'
-    return filePath.replace(/([\s\(\)])/g, escapePrefix + '$1')
+    return filePath.replace(/([\(\)])/g, escapePrefix + '$1')


### PR DESCRIPTION
Hi,
I encountered an issue while using git-time-machine. After some investigation I have found out that if my path in windows containted a space character (for example C:\Test Page) git log command would try running like 
`git log ..... C:\Test^ Page`
Usually this is not an issue while running in windows console but for some reason it did not work while in atom.io editor (it returned an error saying that C:\Test is not in git repository). For this reason you can see my fix in this pull request.

What I did was wrap the fileName in " " and removed changing \s in _escapeForCli so the path with spaces work. I tested this change and now git-time-machine works on windows when path has space in it.

On the other hand I am not sure if while using " " the _escapeForCli is still neessary so that might need some thinking.
